### PR TITLE
Update README to register notifications before starting reading them

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ let peripheralManager = RxPeripheralManager()
 peripheralManager
     .isConnected
     .filter { $0 } // wait until we're connected before performing BLE operations
+    .flatMapLatest{ _ -> Observable<()>
+        // register to listen to pheripheral notifications
+        return self.pheripheralManager.queue(operation: RegisterNotification(service: serviceUUID, characteristic: characteristicUUID))
+    }
     .flatMapLatest { _ -> Observable<Data> in
         // listen for Heart Rate Measurement events
         return self.peripheralManager.receiveNotifications(for: CBUUID(string: "2A37"))

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ peripheralManager
     .filter { $0 } // wait until we're connected before performing BLE operations
     .flatMapLatest{ _ -> Observable<()>
         // register to listen to pheripheral notifications
-        return self.pheripheralManager.queue(operation: RegisterNotification(service: serviceUUID, characteristic: characteristicUUID))
+        let operation = RegisterNotification(service: serviceUUID, characteristic: characteristicUUID)
+        return self.peripheralManager.queue(operation: operation)
     }
     .flatMapLatest { _ -> Observable<Data> in
         // listen for Heart Rate Measurement events


### PR DESCRIPTION
`peripheralManager.receiveNotifications` only works after actually registering to receive that notification. I added a line in the readme to reflect this configuration needing to be set before using it