### PR TITLE
Fix doFinally rx extension

### DIFF
--- a/Sources/RxCBCentral/core/RxPeripheralManager.swift
+++ b/Sources/RxCBCentral/core/RxPeripheralManager.swift
@@ -108,8 +108,15 @@ fileprivate struct GattQueue {
 
 extension ObservableType {
     func doFinally(_ finally: @escaping () -> ()) -> Observable<Element> {
-        return `do`(onError: { _ in finally() },
-                    onCompleted: finally,
-                    onDispose: finally)
+		var didEmit = false
+		let invoke = {
+			guard !didEmit else { return }
+			didEmit = true
+			finally()
+		}
+		
+		return `do`(onError: { _ in invoke() },
+					onCompleted: invoke,
+					onDispose: invoke)
     }
 }


### PR DESCRIPTION
# Expected behavior
Underlying peripheral queue should execute all operations in sequential manner. 
# The issue
Peripheral queue is not executing operations sequentially when there are more than 2 operations enqueued.
Receiving side would get interleaving chunks for different incoming packets.
# Reason
`public func queue<O: GattOperation>(operation: O) -> Single<O.Element>` returns sequence with injected side-effects utilizing internal state to manage/run operation queue in case there are more operations to be executed. `doFinally` rx extension was added to enqueue next operation when the current one finishes, however it's not implemented correctly.
Rx lifecycle usually looking like this:

==...==completed==disposed=|
==...==error==disposed=|
Please note: subscription is disposed **immediately** after completed/error event occurs.

`doFinally` is called **twice** per single operation (e.g. completed, disposed) and due to side-effects utilizing internal state it skips freshly enqueued operation (which will still complete!) and moves to the next one.

Example:
- Schedule 3 write operations
- `Write1` completes
- `doFinally` is executed for `Write1` because of the completed event so `Write #2` is enqueued
- `doFinally` is executed *again* for `Write1` because subscription will be disposed so `Write #3` will be enqueued
- We are now sending packets both for `Write2` and `Write3` simultaneously

Added test to cover this behavior. Revert my change to `doFinally` to see test failing with previous logic: receiving side would get _"Packet 1 containing dummy dataPackeP3t 2 containing slightly more dummy data than first packet"_ instead of _"Packet 1 containing dummy dataPacket 2 containing slightly more dummy data than first packetP3"_
# Fix
Added variable to guard against multiple invocations.